### PR TITLE
Feature : Rotate Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,18 @@ Overlay image on top of background image
 | position   | CGPoint               | Yes      | Position of overlay image in background image                          |
 
 ### [image flip]
-Flip the image horizontally and/or vertically
+Flip the image horizontally, vertically or both
 
 | NAME       | TYPE                  | REQUIRED | DESCRIPTION                                                            |
 |------------|-----------------------|----------|------------------------------------------------------------------------|
 | mode       | FlipMode              | Yes      | Flip mode .Vertical or .Horizontal or .Both                            |
+
+### [image rotate]
+Rotate the image 90°, 180° or 270°
+
+| NAME       | TYPE                  | REQUIRED | DESCRIPTION                                                            |
+|------------|-----------------------|----------|------------------------------------------------------------------------|
+| mode       | RotationMode          | Yes      | Rotation mode .R90 (90° Clockwise), .R180 (180° Half Rotation) or .R270 (270° Clockwise, aka 90° Counterclockwise)                            |
 
 
 ## Usage FileUtils

--- a/WCPhotoManipulator.xcodeproj/project.pbxproj
+++ b/WCPhotoManipulator.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		CA10C5262BB331B7008464A7 /* FlipMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA10C5252BB331B7008464A7 /* FlipMode.swift */; };
+		CA11C0FB2C0C1E9B005542AA /* RotationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA11C0FA2C0C1E9B005542AA /* RotationMode.swift */; };
 		CC92AF5124D250160061CC87 /* FoolSonarcloud.m in Sources */ = {isa = PBXBuildFile; fileRef = CC92AF5024D250160061CC87 /* FoolSonarcloud.m */; };
 		CC92AF6A24D545070061CC87 /* BitmapUtilsSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC92AF6924D545070061CC87 /* BitmapUtilsSwiftTests.swift */; };
 		CC92AF6C24D558500061CC87 /* FileUtilsSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC92AF6B24D558500061CC87 /* FileUtilsSwiftTests.swift */; };
@@ -53,6 +54,7 @@
 
 /* Begin PBXFileReference section */
 		CA10C5252BB331B7008464A7 /* FlipMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlipMode.swift; sourceTree = "<group>"; };
+		CA11C0FA2C0C1E9B005542AA /* RotationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationMode.swift; sourceTree = "<group>"; };
 		CC92AF4F24D250160061CC87 /* FoolSonarcloud.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FoolSonarcloud.h; sourceTree = "<group>"; };
 		CC92AF5024D250160061CC87 /* FoolSonarcloud.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FoolSonarcloud.m; sourceTree = "<group>"; };
 		CC92AF6924D545070061CC87 /* BitmapUtilsSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapUtilsSwiftTests.swift; sourceTree = "<group>"; };
@@ -123,11 +125,12 @@
 			children = (
 				CCC2506B24D05C97000BAC48 /* BitmapUtils.swift */,
 				CCC2505824CFF0C1000BAC48 /* FileUtils.swift */,
+				CA10C5252BB331B7008464A7 /* FlipMode.swift */,
 				CC92AF4F24D250160061CC87 /* FoolSonarcloud.h */,
 				CC92AF5024D250160061CC87 /* FoolSonarcloud.m */,
 				CCC2503B24CFDE4B000BAC48 /* MimeUtils.swift */,
 				CCC2506D24D05EE7000BAC48 /* ResizeMode.swift */,
-				CA10C5252BB331B7008464A7 /* FlipMode.swift */,
+				CA11C0FA2C0C1E9B005542AA /* RotationMode.swift */,
 				CCC2506F24D060C9000BAC48 /* UIImage+PhotoManipulator.swift */,
 				CCC2505124CFE1D2000BAC48 /* WCPhotoManipulator-Bridging-Header.h */,
 			);
@@ -269,6 +272,7 @@
 			files = (
 				CCC2506C24D05C97000BAC48 /* BitmapUtils.swift in Sources */,
 				CCC2507024D060C9000BAC48 /* UIImage+PhotoManipulator.swift in Sources */,
+				CA11C0FB2C0C1E9B005542AA /* RotationMode.swift in Sources */,
 				CA10C5262BB331B7008464A7 /* FlipMode.swift in Sources */,
 				CCC2503C24CFDE4B000BAC48 /* MimeUtils.swift in Sources */,
 				CC92AF5124D250160061CC87 /* FoolSonarcloud.m in Sources */,

--- a/WCPhotoManipulator/RotationMode.swift
+++ b/WCPhotoManipulator/RotationMode.swift
@@ -1,0 +1,23 @@
+//
+//  RotationMode.swift
+//  WCPhotoManipulator
+//
+//  Created by Woraphot Chokratanasombat on 2/6/2567 BE.
+//  Copyright © 2567 BE Woraphot Chokratanasombat. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+@objc public enum RotationMode: Int {
+    case None = 0, R90 = 90, R180 = 180, R270 = 270
+    
+    func transform() -> CGAffineTransform {
+        switch self {
+        case .None:
+            return CGAffineTransformIdentity
+        default:
+            return CGAffineTransformMakeRotation(-CGFloat(self.rawValue) * CGFloat.pi / 180.0)
+        }
+     }
+}

--- a/WCPhotoManipulator/RotationMode.swift
+++ b/WCPhotoManipulator/RotationMode.swift
@@ -13,11 +13,8 @@ import UIKit
     case None = 0, R90 = 90, R180 = 180, R270 = 270
     
     func transform() -> CGAffineTransform {
-        switch self {
-        case .None:
-            return CGAffineTransformIdentity
-        default:
-            return CGAffineTransformMakeRotation(-CGFloat(self.rawValue) * CGFloat.pi / 180.0)
-        }
+        if (self == .None) { return CGAffineTransformIdentity }
+        
+        return CGAffineTransformMakeRotation(-CGFloat(self.rawValue) * CGFloat.pi / 180.0)
      }
 }

--- a/WCPhotoManipulator/RotationMode.swift
+++ b/WCPhotoManipulator/RotationMode.swift
@@ -13,8 +13,6 @@ import UIKit
     case None = 0, R90 = 90, R180 = 180, R270 = 270
     
     func transform() -> CGAffineTransform {
-        if (self == .None) { return CGAffineTransformIdentity }
-        
         return CGAffineTransformMakeRotation(-CGFloat(self.rawValue) * CGFloat.pi / 180.0)
      }
 }

--- a/WCPhotoManipulator/UIImage+PhotoManipulator.swift
+++ b/WCPhotoManipulator/UIImage+PhotoManipulator.swift
@@ -119,7 +119,9 @@ public extension UIImage {
     
     // Flip
     @objc func rotate(_ rotateMode: RotationMode) -> UIImage {
-        if (rotateMode == .None) { return self }
+        if (rotateMode == .None) {
+            return self
+        }
 
         let cgimage = ciImage().transformed(by: rotateMode.transform())
         return UIImage(ciImage: cgimage)
@@ -127,7 +129,10 @@ public extension UIImage {
     
     // Flip
     @objc func ciImage() -> CIImage {
-        if (ciImage != nil) { return ciImage! }
+        if (ciImage != nil) {
+            return ciImage!
+        }
+
         return CIImage(cgImage: cgImage!)
     }
 }

--- a/WCPhotoManipulator/UIImage+PhotoManipulator.swift
+++ b/WCPhotoManipulator/UIImage+PhotoManipulator.swift
@@ -118,6 +118,14 @@ public extension UIImage {
     }
     
     // Flip
+    @objc func rotate(_ rotateMode: RotationMode) -> UIImage {
+        if (rotateMode == .None) { return self }
+
+        let cgimage = ciImage().transformed(by: rotateMode.transform())
+        return UIImage(ciImage: cgimage)
+    }
+    
+    // Flip
     @objc func ciImage() -> CIImage {
         return (ciImage != nil) ? ciImage! : CIImage(cgImage: cgImage!)
     }

--- a/WCPhotoManipulator/UIImage+PhotoManipulator.swift
+++ b/WCPhotoManipulator/UIImage+PhotoManipulator.swift
@@ -127,6 +127,7 @@ public extension UIImage {
     
     // Flip
     @objc func ciImage() -> CIImage {
-        return (ciImage != nil) ? ciImage! : CIImage(cgImage: cgImage!)
+        if (ciImage != nil) { return ciImage! }
+        return CIImage(cgImage: cgImage!)
     }
 }

--- a/WCPhotoManipulatorTests/UIImage+PhotoManipulatorObjCTests.m
+++ b/WCPhotoManipulatorTests/UIImage+PhotoManipulatorObjCTests.m
@@ -158,4 +158,44 @@
     XCTAssertEqual(image4.size.width, 800);
     XCTAssertEqual(image4.size.height, 530);
 }
+
+- (void)testRotate_WhenR90_ShouldReturnCorrectly {
+    image = [UIImage imageNamedTest:@"background.jpg"];
+    XCTAssertNotNil(image);
+    
+    image = [image rotate:RotationModeR90];
+    XCTAssertNotNil(image);
+    XCTAssertEqual(image.size.width, 530);
+    XCTAssertEqual(image.size.height, 800);
+}
+
+- (void)testRotate_WhenR180_ShouldReturnCorrectly {
+    image = [UIImage imageNamedTest:@"background.jpg"];
+    XCTAssertNotNil(image);
+    
+    image = [image rotate:RotationModeR180];
+    XCTAssertNotNil(image);
+    XCTAssertEqual(image.size.width, 800);
+    XCTAssertEqual(image.size.height, 530);
+}
+
+- (void)testRotate_WhenR270_ShouldReturnCorrectly {
+    image = [UIImage imageNamedTest:@"background.jpg"];
+    XCTAssertNotNil(image);
+    
+    image = [image rotate:RotationModeR270];
+    XCTAssertNotNil(image);
+    XCTAssertEqual(image.size.width, 530);
+    XCTAssertEqual(image.size.height, 800);
+}
+
+- (void)testRotate_WhenNone_ShouldReturnCorrectly {
+    image = [UIImage imageNamedTest:@"background.jpg"];
+    XCTAssertNotNil(image);
+    
+    image = [image rotate:RotationModeNone];
+    XCTAssertNotNil(image);
+    XCTAssertEqual(image.size.width, 800);
+    XCTAssertEqual(image.size.height, 530);
+}
 @end

--- a/WCPhotoManipulatorTests/UIImage+PhotoManipulatorSwiftTests.swift
+++ b/WCPhotoManipulatorTests/UIImage+PhotoManipulatorSwiftTests.swift
@@ -74,7 +74,8 @@ class UIImage_PhotoManipulatorSwiftTests: XCTestCase {
         XCTAssertEqual(image.size, CGSize(width: 332, height: 70))
         XCTAssertEqual(actualColor, expectedColor)
     }
-    
+
+    // Draw Text
     func testDrawText_WhenUseFontAndNoScale_ShouldReturnCorrectly() throws {
         image = UIImage.init(namedTest: "background.jpg")
         XCTAssertNotNil(image)
@@ -111,6 +112,7 @@ class UIImage_PhotoManipulatorSwiftTests: XCTestCase {
         XCTAssertEqual(image.size, CGSize(width: 800, height: 530))
     }
 
+    // Overlay Image
     func testOverlayImage_WhenNoScale_ShouldReturnCorrectly() throws {
         image = UIImage.init(namedTest: "background.jpg")
         overlay = UIImage.init(namedTest: "overlay.png")
@@ -130,7 +132,8 @@ class UIImage_PhotoManipulatorSwiftTests: XCTestCase {
         XCTAssertNotNil(image)
         XCTAssertEqual(image.size, CGSize(width: 800, height: 530))
     }
-    
+
+    // Flip
     func testFlip_WhenHasHorizontal_ShouldReturnCorrectly() throws {
         image = UIImage.init(namedTest: "background.jpg")
         XCTAssertNotNil(image)
@@ -178,5 +181,42 @@ class UIImage_PhotoManipulatorSwiftTests: XCTestCase {
         let image4 = image3.flip(.Horizontal)
         XCTAssertNotNil(image4)
         XCTAssertEqual(image4.size, CGSize(width: 800, height: 530))
+    }
+
+    // Rotate
+    func testRotate_WhenR90_ShouldReturnCorrectly() throws {
+        image = UIImage.init(namedTest: "background.jpg")
+        XCTAssertNotNil(image)
+        
+        let actual = image.rotate(.R90)
+        XCTAssertNotNil(actual)
+        XCTAssertEqual(actual.size, CGSize(width: 530, height: 800))
+    }
+    
+    func testRotate_WhenR180_ShouldReturnCorrectly() throws {
+        image = UIImage.init(namedTest: "background.jpg")
+        XCTAssertNotNil(image)
+        
+        let actual = image.rotate(.R180)
+        XCTAssertNotNil(actual)
+        XCTAssertEqual(actual.size, CGSize(width: 800, height: 530))
+    }
+    
+    func testRotate_WhenR270_ShouldReturnCorrectly() throws {
+        image = UIImage.init(namedTest: "background.jpg")
+        XCTAssertNotNil(image)
+        
+        let actual = image.rotate(.R270)
+        XCTAssertNotNil(actual)
+        XCTAssertEqual(actual.size, CGSize(width: 530, height: 800))
+    }
+    
+    func testRotate_WhenNone_ShouldReturnCorrectly() throws {
+        image = UIImage.init(namedTest: "background.jpg")
+        XCTAssertNotNil(image)
+        
+        let actual = image.rotate(.None)
+        XCTAssertNotNil(actual)
+        XCTAssertEqual(actual.size, CGSize(width: 800, height: 530))
     }
 }


### PR DESCRIPTION
Add support for rotate image 90°, 180° or 270° (Implements for [react-native-photo-manipulator#803](https://github.com/guhungry/react-native-photo-manipulator/issues/803))

| Rotation Mode      | Image      |
| ------------- | ------------- |
| Original | ![0-original](https://github.com/guhungry/ios-photo-manipulator/assets/4032276/5d00710f-9cd4-4fed-95bb-2c78d277dd1f) |
| 90° Clockwise | ![1-90](https://github.com/guhungry/ios-photo-manipulator/assets/4032276/09c1785b-6cd7-409b-a6ac-1ea355e65192) |
| 180° or Half Rotation | ![2-180](https://github.com/guhungry/ios-photo-manipulator/assets/4032276/2b464129-b7b2-4736-b779-5e8a9e9000b9) |
| 270° Clockwise or 90° Counterclockwise | ![3-270](https://github.com/guhungry/ios-photo-manipulator/assets/4032276/b40ddfcd-edc8-4b60-b4ba-7c9455c3f642) |