### PR TITLE
feat(drawText): add support for text alignment (left, right)

### DIFF
--- a/Sources/WCPhotoManipulator/Models/TextStyle.swift
+++ b/Sources/WCPhotoManipulator/Models/TextStyle.swift
@@ -14,6 +14,8 @@ import UIKit
     let color: UIColor
     /// The font of the text.
     let font: UIFont
+    /// The alignment of the text. Default value is left.
+    public var alignment: NSTextAlignment = .left
     /// The thickness of the text. Default value is 0.
     let thickness: CGFloat
     /// The rotation angle of the text in degrees. Default value is 0.
@@ -135,6 +137,7 @@ import UIKit
         TextStyle:
           color: \(color)
           font: \(font)
+          alignment: \(alignment)
           thickness: \(thickness)
           rotation: \(rotation)
           shadowRadius: \(shadowRadius)

--- a/Sources/WCPhotoManipulator/Models/TextStyle.swift
+++ b/Sources/WCPhotoManipulator/Models/TextStyle.swift
@@ -15,7 +15,7 @@ import UIKit
     /// The font of the text.
     let font: UIFont
     /// The alignment of the text. Default value is left.
-    public var alignment: NSTextAlignment = .left
+    let alignment: NSTextAlignment
     /// The thickness of the text. Default value is 0.
     let thickness: CGFloat
     /// The rotation angle of the text in degrees. Default value is 0.
@@ -47,9 +47,11 @@ import UIKit
     ///   - shadowOffsetX: The horizontal offset of the shadow. Default is 0.
     ///   - shadowOffsetY: The vertical offset of the shadow. Default is 0.
     ///   - shadowColor: The color of the shadow. Default is nil.
-    @objc public init(color: UIColor, font: UIFont, thickness: CGFloat, rotation: CGFloat, shadowRadius: CGFloat, shadowOffsetX: Int, shadowOffsetY: Int, shadowColor: UIColor?) {
+    ///   - alignment: The alignment of the. Default is left.
+    @objc public init(color: UIColor, font: UIFont, thickness: CGFloat, rotation: CGFloat, shadowRadius: CGFloat, shadowOffsetX: Int, shadowOffsetY: Int, shadowColor: UIColor?, alignment: NSTextAlignment) {
         self.color = color
         self.font = font
+        self.alignment = alignment
         self.thickness = thickness
         self.rotation = rotation
         self.shadowRadius = shadowRadius
@@ -87,6 +89,10 @@ import UIKit
         self.init(color: color, font: font, thickness: thickness, rotation: rotation, shadowRadius: 0, shadowOffsetX: 0, shadowOffsetY: 0, shadowColor: nil)
     }
 
+    @objc public convenience init(color: UIColor, font: UIFont, thickness: CGFloat, rotation: CGFloat, shadowRadius: CGFloat, shadowOffsetX: Int, shadowOffsetY: Int, shadowColor: UIColor?) {
+        self.init(color: color, font: font, thickness: thickness, rotation: rotation, shadowRadius: 0, shadowOffsetX: 0, shadowOffsetY: 0, shadowColor: nil, alignment: .left)
+    }
+
     /// Convenience initializer with color, size, and other optional properties.
     ///
     /// - Parameters:
@@ -99,7 +105,22 @@ import UIKit
     ///   - shadowOffsetY: The vertical offset of the shadow. Default is 0.
     ///   - shadowColor: The color of the shadow. Default is nil.
     @objc public convenience init(color: UIColor, size: CGFloat, thickness: CGFloat, rotation: CGFloat, shadowRadius: CGFloat, shadowOffsetX: Int, shadowOffsetY: Int, shadowColor: UIColor?) {
-        self.init(color: color, font: UIFont.systemFont(ofSize: size), thickness: thickness, rotation: rotation, shadowRadius: shadowRadius, shadowOffsetX: shadowOffsetX, shadowOffsetY: shadowOffsetY, shadowColor: shadowColor)
+        self.init(color: color, size: size, thickness: thickness, rotation: rotation, shadowRadius: shadowRadius, shadowOffsetX: shadowOffsetX, shadowOffsetY: shadowOffsetY, shadowColor: shadowColor, alignment: .left)
+    }
+    
+    /// Convenience initializer with color, size, and other optional properties.
+    ///
+    /// - Parameters:
+    ///   - color: The color of the text.
+    ///   - size: The size of the text's font.
+    ///   - thickness: The thickness of the text. Default is 0.
+    ///   - rotation: The rotation angle of the text in degrees. Default is 0.
+    ///   - shadowRadius: The blur radius of the shadow. Default is 0.
+    ///   - shadowOffsetX: The horizontal offset of the shadow. Default is 0.
+    ///   - shadowOffsetY: The vertical offset of the shadow. Default is 0.
+    ///   - shadowColor: The color of the shadow. Default is nil.
+    @objc public convenience init(color: UIColor, size: CGFloat, thickness: CGFloat, rotation: CGFloat, shadowRadius: CGFloat, shadowOffsetX: Int, shadowOffsetY: Int, shadowColor: UIColor?, alignment: NSTextAlignment) {
+        self.init(color: color, font: UIFont.systemFont(ofSize: size), thickness: thickness, rotation: rotation, shadowRadius: shadowRadius, shadowOffsetX: shadowOffsetX, shadowOffsetY: shadowOffsetY, shadowColor: shadowColor, alignment: alignment)
     }
 
     /// Convenience initializer with only color and size.

--- a/Tests/WCPhotoManipulatorTests/Models/TextStyleTests.swift
+++ b/Tests/WCPhotoManipulatorTests/Models/TextStyleTests.swift
@@ -26,6 +26,7 @@ final class TextStyleTests: XCTestCase {
         let shadowOffsetX: Int = 3
         let shadowOffsetY: Int = 4
         let shadowColor: UIColor? = UIColor.black
+        let alignment: NSTextAlignment = .right
 
         let textStyle = TextStyle(
             color: color,
@@ -35,7 +36,8 @@ final class TextStyleTests: XCTestCase {
             shadowRadius: shadowRadius,
             shadowOffsetX: shadowOffsetX,
             shadowOffsetY: shadowOffsetY,
-            shadowColor: shadowColor
+            shadowColor: shadowColor,
+            alignment: alignment
         )
 
         // When
@@ -46,6 +48,7 @@ final class TextStyleTests: XCTestCase {
         TextStyle:
           color: \(color)
           font: \(font)
+          alignment: \(alignment)
           thickness: \(thickness)
           rotation: \(rotation)
           shadowRadius: \(shadowRadius)

--- a/Tests/WCPhotoManipulatorTests/UIImage+PhotoManipulatorSwiftTests.swift
+++ b/Tests/WCPhotoManipulatorTests/UIImage+PhotoManipulatorSwiftTests.swift
@@ -136,6 +136,23 @@ class UIImage_PhotoManipulatorSwiftTests: XCTestCase {
         XCTAssertNotNil(image)
         XCTAssertEqual(image.size, CGSize(width: 800, height: 530))
     }
+    
+    func testDrawText_WhenAlignRight_ShouldReturnCorrectly() throws {
+        image = UIImage.init(namedTest: "background.jpg")
+        XCTAssertNotNil(image)
+
+        let style = TextStyle(color: .blue, size: 42, thickness: 5, rotation: -30)
+        style.alignment = .right
+        image = image.drawText("Test Text To Align Right Draw", position: CGPoint(x: 400, y: 60), style: style, scale: 2)
+        image = image.drawText("Right", position: CGPoint(x: 400, y: 100), style: style, scale: 2)
+        image = image.drawText("Right Multiple\nLine", position: CGPoint(x: 400, y: 140), style: style, scale: 2)
+        style.alignment = .left
+        image = image.drawText("Test Text To Align Left Draw", position: CGPoint(x: 400, y: 60), style: style, scale: 2)
+        image = image.drawText("Left", position: CGPoint(x: 400, y: 100), style: style, scale: 2)
+        image = image.drawText("Left Multiple\nLine", position: CGPoint(x: 400, y: 140), style: style, scale: 2)
+        XCTAssertNotNil(image)
+        XCTAssertEqual(image.size, CGSize(width: 800, height: 530))
+    }
 
     // Overlay Image
     func testOverlayImage_WhenNoScale_ShouldReturnCorrectly() throws {

--- a/Tests/WCPhotoManipulatorTests/UIImage+PhotoManipulatorSwiftTests.swift
+++ b/Tests/WCPhotoManipulatorTests/UIImage+PhotoManipulatorSwiftTests.swift
@@ -141,15 +141,16 @@ class UIImage_PhotoManipulatorSwiftTests: XCTestCase {
         image = UIImage.init(namedTest: "background.jpg")
         XCTAssertNotNil(image)
 
-        let style = TextStyle(color: .blue, size: 42, thickness: 5, rotation: -30)
-        style.alignment = .right
-        image = image.drawText("Test Text To Align Right Draw", position: CGPoint(x: 400, y: 60), style: style, scale: 2)
-        image = image.drawText("Right", position: CGPoint(x: 400, y: 100), style: style, scale: 2)
-        image = image.drawText("Right Multiple\nLine", position: CGPoint(x: 400, y: 140), style: style, scale: 2)
-        style.alignment = .left
-        image = image.drawText("Test Text To Align Left Draw", position: CGPoint(x: 400, y: 60), style: style, scale: 2)
-        image = image.drawText("Left", position: CGPoint(x: 400, y: 100), style: style, scale: 2)
-        image = image.drawText("Left Multiple\nLine", position: CGPoint(x: 400, y: 140), style: style, scale: 2)
+        let right = TextStyle(color: .blue, size: 42, thickness: 5, rotation: -30, shadowRadius: 0, shadowOffsetX: 0, shadowOffsetY: 0, shadowColor: nil, alignment: .right)
+        image = image.drawText("Test Text To Align Right Draw", position: CGPoint(x: 400, y: 60), style: right, scale: 2)
+        image = image.drawText("Right", position: CGPoint(x: 400, y: 100), style: right, scale: 2)
+        image = image.drawText("Right Multiple\nLine", position: CGPoint(x: 400, y: 140), style: right, scale: 2)
+
+        let left = TextStyle(color: .blue, size: 42, thickness: 5, rotation: -30, shadowRadius: 0, shadowOffsetX: 0, shadowOffsetY: 0, shadowColor: nil, alignment: .left)
+        image = image.drawText("Test Text To Align Left Draw", position: CGPoint(x: 400, y: 60), style: left, scale: 2)
+        image = image.drawText("Left", position: CGPoint(x: 400, y: 100), style: left, scale: 2)
+        image = image.drawText("Left Multiple\nLine", position: CGPoint(x: 400, y: 140), style: left, scale: 2)
+
         XCTAssertNotNil(image)
         XCTAssertEqual(image.size, CGSize(width: 800, height: 530))
     }


### PR DESCRIPTION
Add support for text alignment (left, right) to accommodate Right-to-Left languages like Arabic, as requested in https://github.com/guhungry/react-native-photo-manipulator/issues/943.

Result:
<img width="993" alt="Screenshot 2567-10-23 at 14 59 51" src="https://github.com/user-attachments/assets/10c7d030-8822-4c60-a969-02cdf16dd0b0">
