### PR TITLE
feat(drawText): add support for text alignment (center)

### DIFF
--- a/Sources/WCPhotoManipulator/UIImage+PhotoManipulator.swift
+++ b/Sources/WCPhotoManipulator/UIImage+PhotoManipulator.swift
@@ -65,6 +65,8 @@ public extension UIImage {
         var adjustedPosition = position
         if (style.alignment == .right) {
             adjustedPosition = CGPoint(x: position.x - textSize.width, y: position.y)
+        } else if (style.alignment == .center) {
+            adjustedPosition = CGPoint(x: position.x - textSize.width / 2, y: position.y)
         }
         
         UIGraphicsBeginImageContextWithOptions(self.size, false, scale)

--- a/Tests/WCPhotoManipulatorTests/UIImage+PhotoManipulatorSwiftTests.swift
+++ b/Tests/WCPhotoManipulatorTests/UIImage+PhotoManipulatorSwiftTests.swift
@@ -154,6 +154,24 @@ class UIImage_PhotoManipulatorSwiftTests: XCTestCase {
         XCTAssertNotNil(image)
         XCTAssertEqual(image.size, CGSize(width: 800, height: 530))
     }
+    
+    func testDrawText_WhenAlignCenter_ShouldReturnCorrectly() throws {
+        image = UIImage.init(namedTest: "background.jpg")
+        XCTAssertNotNil(image)
+        
+        let center = TextStyle(color: .blue, size: 42, thickness: 5, rotation: -30, shadowRadius: 0, shadowOffsetX: 0, shadowOffsetY: 0, shadowColor: nil, alignment: .center)
+        image = image.drawText("Test Text To Align Center Draw", position: CGPoint(x: 400, y: 60), style: center, scale: 2)
+        image = image.drawText("Center", position: CGPoint(x: 400, y: 100), style: center, scale: 2)
+        image = image.drawText("Center Multiple\nLine", position: CGPoint(x: 400, y: 140), style: center, scale: 2)
+
+        let left = TextStyle(color: .blue, size: 42, thickness: 5, rotation: -30, shadowRadius: 0, shadowOffsetX: 0, shadowOffsetY: 0, shadowColor: nil, alignment: .left)
+        image = image.drawText("Test Text To Align Left Draw", position: CGPoint(x: 400, y: 60), style: left, scale: 2)
+        image = image.drawText("Left", position: CGPoint(x: 400, y: 100), style: left, scale: 2)
+        image = image.drawText("Left Multiple\nLine", position: CGPoint(x: 400, y: 140), style: left, scale: 2)
+
+        XCTAssertNotNil(image)
+        XCTAssertEqual(image.size, CGSize(width: 800, height: 530))
+    }
 
     // Overlay Image
     func testOverlayImage_WhenNoScale_ShouldReturnCorrectly() throws {


### PR DESCRIPTION
Add support for text alignment center for completion, as requested in https://github.com/JimmyDaddy/react-native-image-marker/issues/83#issuecomment-2437232968

Example: Compare with Left at the same location
<img width="683" alt="Screenshot 2567-10-26 at 10 48 51" src="https://github.com/user-attachments/assets/0b67f5d3-f253-4ceb-bbc0-3ea1768b32e0">
